### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-and-package:
     name: Test, Analyze, and Package
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/v1vhm/pwsh-module-port/security/code-scanning/1](https://github.com/v1vhm/pwsh-module-port/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with the minimum required privileges for the workflow/job. Because the job does not push changes or modify issues, it is safest to set `contents: read` at the job level. This restricts the GITHUB_TOKEN for this job to only read repository contents, adhering to the principle of least privilege. The change should be added under the `test-and-package` job definition, immediately after its `name:` (line 11), so each run is protected by appropriately scoped permissions. No imports or additional functionality are needed—just the addition of the YAML key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
